### PR TITLE
deps: changed tailwind-variants from ^2.1.0 to 2.0.1

### DIFF
--- a/.changeset/forty-rice-attend.md
+++ b/.changeset/forty-rice-attend.md
@@ -1,0 +1,5 @@
+---
+"@sveltique/components": patch
+---
+
+Downgraded tailwind-variants from ^2.1.0 to 2.0.1 to fix [class merging issues](https://github.com/heroui-inc/tailwind-variants/issues/258)

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -53,11 +53,11 @@
 		},
 		"../packages/components": {
 			"name": "@sveltique/components",
-			"version": "0.1.0",
-			"license": "./LICENSE",
+			"version": "0.2.1",
+			"license": "MIT",
 			"dependencies": {
 				"tailwind-merge": "^3.3.1",
-				"tailwind-variants": "^2.1.0"
+				"tailwind-variants": "2.0.1"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4901,25 +4901,6 @@
 				"url": "https://github.com/sponsors/dcastil"
 			}
 		},
-		"node_modules/tailwind-variants": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/tailwind-variants/-/tailwind-variants-2.1.0.tgz",
-			"integrity": "sha512-82m0eRex0z6A3GpvfoTCpHr+wWJmbecfVZfP3mqLoDxeya5tN4mYJQZwa5Aw1hRZTedwpu1D2JizYenoEdyD8w==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=16.x",
-				"pnpm": ">=7.x"
-			},
-			"peerDependencies": {
-				"tailwind-merge": ">=3.0.0",
-				"tailwindcss": "*"
-			},
-			"peerDependenciesMeta": {
-				"tailwind-merge": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/tailwindcss": {
 			"version": "4.1.12",
 			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.12.tgz",
@@ -5581,11 +5562,11 @@
 		},
 		"packages/components": {
 			"name": "@sveltique/components",
-			"version": "0.1.0",
-			"license": "./LICENSE",
+			"version": "0.2.1",
+			"license": "MIT",
 			"dependencies": {
 				"tailwind-merge": "^3.3.1",
-				"tailwind-variants": "^2.1.0"
+				"tailwind-variants": "2.0.1"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.2.2",
@@ -5608,6 +5589,25 @@
 			},
 			"peerDependencies": {
 				"svelte": "^5.25.0"
+			}
+		},
+		"packages/components/node_modules/tailwind-variants": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/tailwind-variants/-/tailwind-variants-2.0.1.tgz",
+			"integrity": "sha512-1wt8c4PWO3jbZcKGBrjIV8cehWarREw1C2os0k8Mcq0nof/CbafNhUUjb0LRWiiRfAvDK6v1deswtHLsygKglw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.x",
+				"pnpm": ">=7.x"
+			},
+			"peerDependencies": {
+				"tailwind-merge": ">=3.0.0",
+				"tailwindcss": "*"
+			},
+			"peerDependenciesMeta": {
+				"tailwind-merge": {
+					"optional": true
+				}
 			}
 		}
 	}

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,16 +1,16 @@
 {
 	"name": "@sveltique/components",
-	"version": "0.1.0",
+	"version": "0.2.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@sveltique/components",
-			"version": "0.1.0",
-			"license": "./LICENSE",
+			"version": "0.2.1",
+			"license": "MIT",
 			"dependencies": {
 				"tailwind-merge": "^3.3.1",
-				"tailwind-variants": "^2.1.0"
+				"tailwind-variants": "2.0.1"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.2.2",
@@ -2858,9 +2858,9 @@
 			}
 		},
 		"node_modules/tailwind-variants": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/tailwind-variants/-/tailwind-variants-2.1.0.tgz",
-			"integrity": "sha512-82m0eRex0z6A3GpvfoTCpHr+wWJmbecfVZfP3mqLoDxeya5tN4mYJQZwa5Aw1hRZTedwpu1D2JizYenoEdyD8w==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/tailwind-variants/-/tailwind-variants-2.0.1.tgz",
+			"integrity": "sha512-1wt8c4PWO3jbZcKGBrjIV8cehWarREw1C2os0k8Mcq0nof/CbafNhUUjb0LRWiiRfAvDK6v1deswtHLsygKglw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=16.x",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,13 +1,7 @@
 {
 	"name": "@sveltique/components",
 	"version": "0.2.1",
-	"keywords": [
-		"svelte",
-		"components",
-		"ui",
-		"sveltekit",
-		"tailwindcss"
-	],
+	"keywords": ["svelte", "components", "ui", "sveltekit", "tailwindcss"],
 	"license": "MIT",
 	"scripts": {
 		"build": "npm run prepack",
@@ -20,14 +14,8 @@
 		"format": "npx @biomejs/biome format --write",
 		"lint": "npx @biomejs/biome lint --write"
 	},
-	"files": [
-		"dist",
-		"!dist/**/*.test.*",
-		"!dist/**/*.spec.*"
-	],
-	"sideEffects": [
-		"**/*.css"
-	],
+	"files": ["dist", "!dist/**/*.test.*", "!dist/**/*.spec.*"],
+	"sideEffects": ["**/*.css"],
 	"svelte": "./dist/components/index.js",
 	"types": "./dist/components/index.d.ts",
 	"type": "module",
@@ -66,7 +54,7 @@
 	},
 	"dependencies": {
 		"tailwind-merge": "^3.3.1",
-		"tailwind-variants": "^2.1.0"
+		"tailwind-variants": "2.0.1"
 	},
 	"peerDependencies": {
 		"svelte": "^5.25.0"


### PR DESCRIPTION
In version 2.1.0 and onwards, there is an [issue](https://github.com/heroui-inc/tailwind-variants/issues/258) when merging base and class props.