### PR TITLE
fix: components expose `ref` as the correct type

### DIFF
--- a/.changeset/silly-crabs-mix.md
+++ b/.changeset/silly-crabs-mix.md
@@ -1,0 +1,5 @@
+---
+"@sveltique/components": patch
+---
+
+Components expose `ref` as the correct type

--- a/packages/components/src/lib/components/accordion/Accordion.svelte
+++ b/packages/components/src/lib/components/accordion/Accordion.svelte
@@ -9,7 +9,7 @@ import { accordion } from "./variants.js";
 
 export interface AccordionProps
 	extends ReplaceWithTWMergeClass<HTMLAttributes<HTMLDivElement>>,
-		WithRef<HTMLElement | HTMLDivElement> {
+		WithRef<HTMLDivElement> {
 	children?: Snippet;
 	/**
 	 * Whether to make the first item expanded by default.

--- a/packages/components/src/lib/components/accordion/AccordionItem.svelte
+++ b/packages/components/src/lib/components/accordion/AccordionItem.svelte
@@ -17,7 +17,7 @@ type IconSnippet = Snippet<
 	]
 >;
 
-export interface AccordionItemProps extends TWMergeClass, WithRef<HTMLElement | HTMLDivElement> {
+export interface AccordionItemProps extends TWMergeClass, WithRef<HTMLDivElement> {
 	children: Snippet;
 	header: string | Snippet;
 	value?: string;

--- a/packages/components/src/lib/components/alert/Alert.svelte
+++ b/packages/components/src/lib/components/alert/Alert.svelte
@@ -15,10 +15,7 @@ type IconSnippet = Snippet<
 	]
 >;
 
-export interface AlertProps
-	extends TWMergeClass,
-		AlertVariants,
-		WithRef<HTMLElement | HTMLDivElement> {
+export interface AlertProps extends TWMergeClass, AlertVariants, WithRef<HTMLDivElement> {
 	children?: Snippet;
 	icon?: IconSnippet;
 }

--- a/packages/components/src/lib/components/aspect-ratio/AspectRatio.svelte
+++ b/packages/components/src/lib/components/aspect-ratio/AspectRatio.svelte
@@ -6,7 +6,7 @@ import { type AspectRatioVariants, aspectRatio } from "./variants.js";
 
 export interface AspectRatioProps
 	extends ReplaceWithTWMergeClass<HTMLAttributes<HTMLElement>>,
-		WithRef<HTMLElement | HTMLDivElement>,
+		WithRef<HTMLDivElement>,
 		AspectRatioVariants {
 	children?: Snippet;
 	ratio: number;

--- a/packages/components/src/lib/components/backdrop/Backdrop.svelte
+++ b/packages/components/src/lib/components/backdrop/Backdrop.svelte
@@ -4,7 +4,7 @@ import { fade } from "svelte/transition";
 import type { TWMergeClass, WithRef } from "$lib/types.js";
 import { backdrop } from "./variants.js";
 
-export interface BackdropProps extends TWMergeClass, WithRef<HTMLElement | HTMLDivElement> {
+export interface BackdropProps extends TWMergeClass, WithRef<HTMLDivElement> {
 	children?: Snippet;
 	/** @default 150 */
 	fadeDuration?: number;

--- a/packages/components/src/lib/components/badge/Badge.svelte
+++ b/packages/components/src/lib/components/badge/Badge.svelte
@@ -3,10 +3,7 @@ import type { Snippet } from "svelte";
 import type { TWMergeClass, WithRef } from "$lib/types.js";
 import { type BadgeVariants, badge } from "./variants.js";
 
-export interface BadgeProps
-	extends BadgeVariants,
-		TWMergeClass,
-		WithRef<HTMLElement | HTMLDivElement> {
+export interface BadgeProps extends BadgeVariants, TWMergeClass, WithRef<HTMLDivElement> {
 	children?: Snippet;
 }
 

--- a/packages/components/src/lib/components/button/Button.svelte
+++ b/packages/components/src/lib/components/button/Button.svelte
@@ -8,7 +8,7 @@ import { type ButtonVariants, button } from "./variants.js";
 export interface ButtonProps
 	extends ReplaceWithTWMergeClass<Omit<HTMLButtonAttributes, "color" | "disabled">>,
 		ButtonVariants,
-		WithRef<HTMLElement | HTMLButtonElement> {}
+		WithRef<HTMLButtonElement> {}
 
 let {
 	children,

--- a/packages/components/src/lib/components/checkbox/Checkbox.svelte
+++ b/packages/components/src/lib/components/checkbox/Checkbox.svelte
@@ -6,7 +6,7 @@ import { type CheckboxVariants, checkbox } from "./variants.js";
 export interface CheckboxProps
 	extends Omit<HTMLInputAttributes, "checked" | "class" | "disabled" | "type">,
 		TWMergeClass,
-		WithRef<HTMLElement | HTMLInputElement>,
+		WithRef<HTMLInputElement>,
 		CheckboxVariants {}
 
 let {

--- a/packages/components/src/lib/components/code-block/CodeBlock.svelte
+++ b/packages/components/src/lib/components/code-block/CodeBlock.svelte
@@ -9,7 +9,7 @@ import { Tooltip } from "../tooltip/index.js";
 import { assembleLines, parseNumberRanges, transformHTMLEntities } from "./code-block.js";
 import { codeBlock } from "./variants.js";
 
-export interface CodeBlockProps extends TWMergeClass, WithRef<HTMLElement | HTMLDivElement> {
+export interface CodeBlockProps extends TWMergeClass, WithRef<HTMLDivElement> {
 	code: string;
 	containerClass?: ClassNameValue;
 	lang: BundledLanguage;

--- a/packages/components/src/lib/components/field/Field.svelte
+++ b/packages/components/src/lib/components/field/Field.svelte
@@ -19,10 +19,7 @@ type InputSnippet = Snippet<
 	]
 >;
 
-export interface FieldProps
-	extends TWMergeClass,
-		WithRef<HTMLElement | HTMLDivElement>,
-		FieldVariants {
+export interface FieldProps extends TWMergeClass, WithRef<HTMLDivElement>, FieldVariants {
 	input: InputSnippet;
 	error?: string | undefined;
 	label?: string | undefined;

--- a/packages/components/src/lib/components/label/Label.svelte
+++ b/packages/components/src/lib/components/label/Label.svelte
@@ -6,7 +6,7 @@ import { type LabelVariants, label } from "./variants.js";
 export interface LabelProps
 	extends ReplaceWithTWMergeClass<HTMLLabelAttributes>,
 		LabelVariants,
-		WithRef<HTMLElement | HTMLLabelElement> {}
+		WithRef<HTMLLabelElement> {}
 
 let { children, class: className, ref = $bindable(), ...restProps }: LabelProps = $props();
 </script>

--- a/packages/components/src/lib/components/link/Link.svelte
+++ b/packages/components/src/lib/components/link/Link.svelte
@@ -18,7 +18,7 @@ type IconSnippet = Snippet<
 
 export interface LinkProps
 	extends ReplaceWithTWMergeClass<HTMLAnchorAttributes>,
-		WithRef<HTMLElement | HTMLAnchorElement>,
+		WithRef<HTMLAnchorElement>,
 		LinkVariants {
 	/**
 	 * Shorthand for setting `target="_blank"` and `rel="noreferrer"`.

--- a/packages/components/src/lib/components/modal/Modal.svelte
+++ b/packages/components/src/lib/components/modal/Modal.svelte
@@ -23,7 +23,7 @@ type ChildrenSnippet = Snippet<
 
 export interface ModalProps
 	extends ReplaceWithTWMergeClass<Omit<HTMLAttributes<HTMLElement>, "children">>,
-		WithRef<HTMLElement | HTMLDivElement>,
+		WithRef<HTMLDivElement>,
 		ModalVariants {
 	actions?: Snippet<[{ close: VoidFunction }]>;
 	children?: ChildrenSnippet;

--- a/packages/components/src/lib/components/number-input/NumberInput.svelte
+++ b/packages/components/src/lib/components/number-input/NumberInput.svelte
@@ -6,7 +6,7 @@ import { type NumberInputVariants, numberInput } from "./variants.js";
 
 export interface NumberInputProps
 	extends Omit<HTMLInputAttributes, "class" | "step" | "min" | "max" | "value">,
-		WithRef<HTMLElement | HTMLDivElement>,
+		WithRef<HTMLDivElement>,
 		NumberInputVariants {
 	containerClass?: string | undefined;
 	class?: ClassNameValue;

--- a/packages/components/src/lib/components/paper/Paper.svelte
+++ b/packages/components/src/lib/components/paper/Paper.svelte
@@ -7,7 +7,7 @@ export interface PaperProps
 	extends Omit<HTMLAttributes<HTMLDivElement>, "class">,
 		TWMergeClass,
 		PaperVariants,
-		WithRef<HTMLElement | HTMLDivElement> {}
+		WithRef<HTMLDivElement> {}
 
 let {
 	children,

--- a/packages/components/src/lib/components/progress/Progress.svelte
+++ b/packages/components/src/lib/components/progress/Progress.svelte
@@ -2,10 +2,7 @@
 import type { TWMergeClass, WithRef } from "$lib/types.js";
 import { type ProgressVariants, progress } from "./variants.js";
 
-export interface ProgressProps
-	extends TWMergeClass,
-		ProgressVariants,
-		WithRef<HTMLElement | HTMLDivElement> {
+export interface ProgressProps extends TWMergeClass, ProgressVariants, WithRef<HTMLDivElement> {
 	value: number;
 }
 

--- a/packages/components/src/lib/components/select/Option.svelte
+++ b/packages/components/src/lib/components/select/Option.svelte
@@ -9,7 +9,7 @@ import { type SelectOptionVariants, selectOption } from "./variants.js";
 export interface SelectOptionProps
 	extends Omit<HTMLAttributes<HTMLLIElement>, "class">,
 		SelectOptionVariants,
-		WithRef<HTMLElement | HTMLLIElement> {
+		WithRef<HTMLLIElement> {
 	/** @default $props.id() */
 	id?: string;
 	value: string;

--- a/packages/components/src/lib/components/select/Select.svelte
+++ b/packages/components/src/lib/components/select/Select.svelte
@@ -5,7 +5,7 @@ import type { ClassNameValue } from "tailwind-merge";
 import type { WithRef } from "$lib/types.js";
 import { type SelectVariants, select } from "./variants.js";
 
-export interface SelectProps extends WithRef<HTMLElement | HTMLDivElement>, SelectVariants {
+export interface SelectProps extends WithRef<HTMLDivElement>, SelectVariants {
 	id?: string;
 	children?: Snippet;
 	class?: ClassNameValue;

--- a/packages/components/src/lib/components/separator/Separator.svelte
+++ b/packages/components/src/lib/components/separator/Separator.svelte
@@ -2,10 +2,7 @@
 import type { TWMergeClass, WithRef } from "$lib/types.js";
 import { type SeparatorVariants, separator } from "./variants.js";
 
-export interface SeparatorProps
-	extends TWMergeClass,
-		WithRef<HTMLElement | HTMLDivElement>,
-		SeparatorVariants {}
+export interface SeparatorProps extends TWMergeClass, WithRef<HTMLDivElement>, SeparatorVariants {}
 
 let {
 	class: className = undefined,

--- a/packages/components/src/lib/components/skeleton/Skeleton.svelte
+++ b/packages/components/src/lib/components/skeleton/Skeleton.svelte
@@ -5,7 +5,7 @@ import { type SkeletonVariants, skeleton } from "./variants.js";
 
 export interface SkeletonProps
 	extends ReplaceWithTWMergeClass<HTMLAttributes<HTMLDivElement>>,
-		WithRef<HTMLElement | HTMLDivElement>,
+		WithRef<HTMLDivElement>,
 		SkeletonVariants {}
 
 let {

--- a/packages/components/src/lib/components/switch/Switch.svelte
+++ b/packages/components/src/lib/components/switch/Switch.svelte
@@ -7,7 +7,7 @@ export interface SwitchProps
 	extends ReplaceWithTWMergeClass<
 			Omit<HTMLButtonAttributes, "disabled" | "onclick" | "ontoggle">
 		>,
-		WithRef<HTMLElement | HTMLButtonElement>,
+		WithRef<HTMLButtonElement>,
 		SwitchVariants {
 	ontoggle?: (checked: boolean) => void;
 }

--- a/packages/components/src/lib/components/text-area/TextArea.svelte
+++ b/packages/components/src/lib/components/text-area/TextArea.svelte
@@ -5,7 +5,7 @@ import { type TextAreaVariants, textArea } from "./variants.js";
 
 export interface TextAreaProps
 	extends ReplaceWithTWMergeClass<Omit<HTMLTextareaAttributes, "value">>,
-		WithRef<HTMLElement | HTMLTextAreaElement>,
+		WithRef<HTMLTextAreaElement>,
 		TextAreaVariants {
 	value?: string;
 }

--- a/packages/components/src/lib/components/text-input/TextInput.svelte
+++ b/packages/components/src/lib/components/text-input/TextInput.svelte
@@ -6,7 +6,7 @@ import { type TextInputVariants, textInput } from "./variants.js";
 export interface TextInputProps
 	extends Omit<HTMLInputAttributes, "class" | "value">,
 		TWMergeClass,
-		WithRef<HTMLElement | HTMLInputElement>,
+		WithRef<HTMLInputElement>,
 		TextInputVariants {
 	value?: string;
 }

--- a/packages/components/src/lib/components/toast/Toast.svelte
+++ b/packages/components/src/lib/components/toast/Toast.svelte
@@ -4,10 +4,7 @@ import type { TWMergeClass, WithRef } from "$lib/types.js";
 import Button from "../button/Button.svelte";
 import { type ToastVariants, toast } from "./variants.js";
 
-export interface ToastProps
-	extends TWMergeClass,
-		WithRef<HTMLElement | HTMLDivElement>,
-		ToastVariants {
+export interface ToastProps extends TWMergeClass, WithRef<HTMLDivElement>, ToastVariants {
 	closeAriaLabel?: string;
 	/** If passed, renders a close button. */
 	onClose?: () => void;

--- a/packages/components/src/lib/components/tooltip/Tooltip.svelte
+++ b/packages/components/src/lib/components/tooltip/Tooltip.svelte
@@ -6,7 +6,11 @@ import type { ClassNameValue } from "tailwind-merge";
 import type { TWMergeClass, WithRef } from "$lib/types.js";
 import { type TooltipVariants, tooltip } from "./variants.js";
 
-type Ref = { current: HTMLElement | undefined };
+type Ref = {
+	/** @note Expects a subclass of `HTMLElement`. */
+	// biome-ignore lint/suspicious/noExplicitAny: Not sure how to allow any subclass type of HTMLElement
+	current: any | undefined;
+};
 
 export interface TooltipProps
 	extends TWMergeClass,

--- a/packages/components/src/lib/components/tooltip/Tooltip.svelte
+++ b/packages/components/src/lib/components/tooltip/Tooltip.svelte
@@ -12,10 +12,7 @@ type Ref = {
 	current: any | undefined;
 };
 
-export interface TooltipProps
-	extends TWMergeClass,
-		WithRef<HTMLElement | HTMLDivElement>,
-		TooltipVariants {
+export interface TooltipProps extends TWMergeClass, WithRef<HTMLDivElement>, TooltipVariants {
 	children?: Snippet<[{ ref: Ref; props: { "aria-describedby": string } }]>;
 	containerClass?: ClassNameValue;
 	id?: string;


### PR DESCRIPTION
The original idea was to allow tooltip to expose an `HTMLElement` and to bind it to any other component. However, if a `ref` is not of the correct type, the component may not work correctly.

I've decided to make the type of the tooltip's `children`'s ref as `{ current: any | undefined }`, but I'm open if anyone has a better idea.