### PR TITLE
docs: playground height adapting based on content height

### DIFF
--- a/docs/src/lib/components/Playground.svelte
+++ b/docs/src/lib/components/Playground.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 import { Paper } from "@sveltique/components";
-import type { Snippet } from "svelte";
+import { onMount, type Snippet } from "svelte";
 import type { ClassNameValue } from "tailwind-merge";
 import { cnBase } from "tailwind-variants";
 import CodeBlock from "./CodeBlock.svelte";
+import { getDynamicHeight } from "$utils/dynamic-height.svelte";
 
 type Code = {
 	short: string;
@@ -19,6 +20,16 @@ interface Props {
 let { children, class: className, code }: Props = $props();
 
 let showCode = $state(false);
+let playgroundRef = $state<HTMLDivElement>();
+
+let playgroundHeight = getDynamicHeight(() => playgroundRef, {
+	min: 400,
+	attribute: "offsetHeight"
+});
+
+let heightStyle = $derived(
+	playgroundHeight.current ? `height: ${playgroundHeight.current}px;` : ""
+);
 </script>
 
 <div data-playground class="relative mb-4 flex w-full flex-col items-start gap-2.5">
@@ -44,13 +55,19 @@ let showCode = $state(false);
 	</div>
 	{#if showCode}
 		<!-- TODO : remove the code?.expanded support -->
-		<CodeBlock
-			code={typeof code === 'string' ? code : (code?.expanded ?? '')}
-			showLineNumbers
-			class="h-[400px]"
-		/>
+		<div style={heightStyle} class="relative w-full">
+            <CodeBlock
+                code={typeof code === 'string' ? code : (code?.expanded ?? '')}
+                showLineNumbers
+                containerClass="h-full"
+            />
+        </div>
 	{:else}
-		<Paper class={cnBase("flex h-[400px] w-full items-center justify-center gap-5 p-6", className)}>
+		<Paper
+            bind:ref={playgroundRef}
+            style={heightStyle}
+            class={cnBase("flex w-full items-center justify-center gap-5 p-6", className)}
+        >
             {@render children?.()}
 		</Paper>
 	{/if}

--- a/docs/src/lib/utils/dynamic-height.svelte.ts
+++ b/docs/src/lib/utils/dynamic-height.svelte.ts
@@ -1,0 +1,38 @@
+import type { MaybeGetter } from "@sveltique/components/types";
+import { onMount } from "svelte";
+import { on } from "svelte/events";
+import { get } from "./getter";
+
+type GetDynamicHeightOptions = {
+	/** @default 0 */
+	min?: number;
+	/**
+	 * The `*Height` attribute to target on the element.
+	 * @default "scrollHeight"
+	 */
+	attribute?: "clientHeight" | "offsetHeight" | "scrollHeight";
+};
+
+export function getDynamicHeight(
+	element: MaybeGetter<HTMLElement | undefined>,
+	options: GetDynamicHeightOptions = {}
+) {
+	const { attribute = "scrollHeight", min = 0 } = options;
+
+	const state = $state({ current: undefined as number | undefined });
+	const _element = $derived(get(element));
+
+	onMount(() => {
+		if (!_element) return;
+
+		state.current = Math.max(min, _element[attribute]);
+
+		return on(window, "resize", () => {
+			if (!_element) return;
+
+			state.current = Math.max(min, _element[attribute]);
+		});
+	});
+
+	return state;
+}

--- a/docs/src/lib/utils/getter.ts
+++ b/docs/src/lib/utils/getter.ts
@@ -1,0 +1,5 @@
+import type { MaybeGetter } from "@sveltique/components/types";
+
+export function get<T>(value: MaybeGetter<T>) {
+	return value instanceof Function ? value() : value;
+}


### PR DESCRIPTION
On mobile, the hard `400px` limit would make the children overflow.

This should fix it by allowing a height greater (but not smaller) than 400px and persist the height when toggling the view tab.