### PR TITLE
fix: `Select.Root` open is now bindable

### DIFF
--- a/.changeset/dark-cameras-guess.md
+++ b/.changeset/dark-cameras-guess.md
@@ -1,0 +1,5 @@
+---
+"@sveltique/components": patch
+---
+
+`Select.Root` open is now bindable

--- a/packages/components/src/lib/components/select/Select.svelte
+++ b/packages/components/src/lib/components/select/Select.svelte
@@ -73,6 +73,7 @@ let {
 	containerProps = {},
 	id,
 	name,
+	open = $bindable(false),
 	placeholder = "",
 	ref = $bindable(),
 	value = $bindable(),
@@ -84,7 +85,6 @@ const componentId = $props.id();
 let triggerRef = $state<HTMLButtonElement>()!;
 let listBoxRef = $state<HTMLUListElement>()!;
 
-let open = $state(false);
 let valueContent = $state<string | undefined>();
 let focusedId = $state<string>();
 


### PR DESCRIPTION
Closes #48 