### PR TITLE
fix: fixed Accordion.Item dynamic heading level

### DIFF
--- a/.changeset/cruel-experts-call.md
+++ b/.changeset/cruel-experts-call.md
@@ -1,0 +1,5 @@
+---
+"@sveltique/components": patch
+---
+
+Fixed `Accordion.Item` dynamic heading level

--- a/packages/components/src/lib/components/accordion/AccordionItem.svelte
+++ b/packages/components/src/lib/components/accordion/AccordionItem.svelte
@@ -51,7 +51,7 @@ const uid = $props.id();
 
 let parent = $state<HTMLDivElement>();
 let open = $state(false);
-let headingLevel = $state<string>()!;
+let headingLevel = $state<string>("");
 
 let _value = $derived(value ?? uid);
 


### PR DESCRIPTION
### Description

The app crashes when using `Accordion.Item` because the default heading level is `undefined`.

Internally, Svelte checks if the `svelte:element` is valid. However, it expects a string value, which is not the case on the first render. Added a default `""`.

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist

- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] The description should clearly illustrate what problems it solves.
- [x] If this PR changes code within `packages/`, add a changeset (`npx changeset`).

#### For component changes

- [x] All necessary types and components are exported.
- [x] Public-facing API is well-documented.
- [x] Component is accessible (ARIA attributes, keyboard navigation).
