### PR TITLE
feat(field): added helper text property

### DIFF
--- a/.changeset/forty-showers-poke.md
+++ b/.changeset/forty-showers-poke.md
@@ -1,0 +1,5 @@
+---
+"@sveltique/components": minor
+---
+
+Added helper text property to `Field` component

--- a/docs/content/components/browse/Field.svelte
+++ b/docs/content/components/browse/Field.svelte
@@ -1,7 +1,7 @@
 <script module>
 export const metadata = {
 	description:
-		"Provides a consistent structure for form controls, by including a label and an error message when provided."
+		"Provides a consistent structure for form controls by integrating a label, helper text, and error message when supplied."
 };
 </script>
 
@@ -43,7 +43,7 @@ const basicUsageCode = `${script('import { Field, TextInput } from "@sveltique/c
     {/snippet}
 </Field>`;
 
-const ageCode = `${script(`import { Field, NumberInput } from '@sveltique/components';
+const errorMessageCode = `${script(`import { Field, NumberInput } from '@sveltique/components';
 
     let age = $state(18);
     let ageError = $derived.by(() => {
@@ -66,6 +66,18 @@ const ageCode = `${script(`import { Field, NumberInput } from '@sveltique/compon
         />
     {/snippet}
 </Field>`;
+
+const helperTextCode = `${script('import { Field, TextInput } from "@sveltique/components";')}
+
+<Field
+    label="Password"
+    helper="Must be at least 8 characters"
+    class="max-w-3xs"
+>
+    {#snippet input({ props })}
+        <TextInput type="password" {...props} />
+    {/snippet}
+</Field>`
 
 const placementCode = `${script('import { Checkbox, Field, Switch } from "@sveltique/components";')}
 
@@ -93,14 +105,14 @@ const placementCode = `${script('import { Checkbox, Field, Switch } from "@svelt
 
 <h1 id="field">Field</h1>
 <p>
-    Provides a consistent structure for form controls, by including a label and an error message when
-    provided.
+    Provides a consistent structure for form controls by integrating a label, helper text, and error
+    message when supplied.
 </p>
 
 <h2 id="basic-usage">Basic Usage</h2>
 <p>
-	A field takes an <Badge variant="secondary">input</Badge> snippet, exposing props for linking
-    the label with the input, and for accessibility purposes.
+	A field takes an <Badge variant="secondary">input</Badge> snippet, exposing props for accessibility
+    purposes.
 </p>
 <p>
     You can use any input element, or custom ones such as <Link href="/docs/components/browse/text-input">
@@ -117,26 +129,42 @@ const placementCode = `${script('import { Checkbox, Field, Switch } from "@svelt
 	</Field>
 </Playground>
 
-<h3 id="error">Error</h3>
-<p>You can show an error message under the field by setting the error property.</p>
+<h3 id="error-message">Error Message</h3>
+<p>
+    You can show an error message under the field by setting the <Badge variant="secondary">error</Badge>
+    property.
+</p>
 <Alert class="mb-4">
     In production code, you would receive the error from a validation library instead of defining
     it manually like in this example.
 </Alert>
-<Playground code={ageCode} class="flex-col">
+<Playground code={errorMessageCode} class="flex-col">
 	<Field label="Age" error={ageError} class="max-w-3xs">
 		{#snippet input({ props })}
 			<NumberInput bind:value={age} min={0} max={99} {...props} />
 		{/snippet}
 	</Field>
-    <p class="text-sm italic text-muted-foreground">
+    <p class="text-muted-foreground text-sm italic">
         Try setting the age above 18 to make the error disappear.
     </p>
 </Playground>
 
+<h3 id="helper-text">Helper text</h3>
+<p>
+    You can show a helper text under the field by setting the <Badge variant="secondary">helper</Badge>
+    property.
+</p>
+<Playground code={helperTextCode} class="flex-col">
+	<Field label="Password" helper="Must be at least 8 characters" class="max-w-3xs">
+		{#snippet input({ props })}
+			<TextInput type="password" {...props} />
+		{/snippet}
+	</Field>
+</Playground>
+
 <h2 id="customization">Customization</h2>
 
-<h3 id="placement">Placement</h3>
+<h3 id="placement">Label Placement</h3>
 <p>
     By default, the label appears on top of the input. However, in somes cases, such as with switches
     or checkboxes, you may want to place the label differently.

--- a/packages/components/src/lib/components/field/variants.ts
+++ b/packages/components/src/lib/components/field/variants.ts
@@ -5,6 +5,7 @@ export const field = tv({
 		container: "relative w-full flex flex-col items-start gap-3",
 		labelInputContainer: "relative w-full flex",
 		error: "text-sm text-danger flex gap-3 items-center",
+		helper: "text-sm text-muted-foreground flex gap-3 items-center",
 		icon: "h-5 aspect-square shrink-0"
 	},
 	variants: {


### PR DESCRIPTION
### Description

Added a `helper` text property to the `Field` component.

Took the time to also improve the phrasing in the docs.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### Checklist

- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] The description should clearly illustrate what problems it solves.
- [x] If this PR changes code within `packages/`, add a changeset (`npx changeset`).

#### For component changes

- [x] All necessary types and components are exported.
- [x] Public-facing API is well-documented.
- [x] Component is accessible (ARIA attributes, keyboard navigation).
