### PR TITLE
fix(select): passing class property to trigger

### DIFF
--- a/.changeset/ready-streets-tap.md
+++ b/.changeset/ready-streets-tap.md
@@ -1,0 +1,5 @@
+---
+"@sveltique/components": patch
+---
+
+Passing `class` property to select trigger

--- a/packages/components/src/lib/components/select/Select.svelte
+++ b/packages/components/src/lib/components/select/Select.svelte
@@ -258,7 +258,7 @@ function getActiveSibling(element: HTMLElement, previous: boolean = true) {
 		aria-controls="{componentId}-listbox"
 		aria-expanded={open}
         aria-haspopup="listbox"
-		class={trigger()}
+		class={trigger({ className })}
 		{...restProps}
 	>
 		<span class={triggerContent()}>


### PR DESCRIPTION
### Description

The `Select` component didn't pass the `class` property to the trigger.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist

- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] The description should clearly illustrate what problems it solves.
- [x] If this PR changes code within `packages/`, add a changeset (`npx changeset`).

#### For component changes

- [x] All necessary types and components are exported.
- [x] Public-facing API is well-documented.
- [x] Component is accessible (ARIA attributes, keyboard navigation).
